### PR TITLE
dockerd-acap: Strip dockerd binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ endif
 
 docker%:
 	curl https://download.docker.com/linux/static/stable/$(DOCKERARCH)/docker-19.03.8.tgz | tar xz --strip-components=1 docker/$@
+	$(STRIP) $@
 
 all:	$(PROGS) $(DOCKS)
 


### PR DESCRIPTION
The prebuilt binary from Docker is not stripped. By doing so, we get a smaller footprint for the ACAP.