### PR TITLE
Consolidate Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM axisecp/acap-sdk:3.2-armv7hf
+ARG ACAPARCH=armv7hf
+FROM axisecp/acap-sdk:3.2-$ACAPARCH
 
 COPY . /opt/app 
 WORKDIR /opt/app

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,0 @@
-FROM axisecp/acap-sdk:3.2-aarch64
-
-COPY . /opt/app 
-WORKDIR /opt/app
-
-RUN . /opt/axis/acapsdk/environment-setup* && create-package.sh
-ENTRYPOINT [ "/opt/axis/acapsdk/sysroots/x86_64-pokysdk-linux/usr/bin/eap-install.sh" ] 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # The Docker Engine ACAP 
+
 This is the ACAP packaging of the Docker Engine to be run on Axis devices with
 container support. Please note that this is ACAP4 alpha and not ready for production
 use. 
 
-## Building
-    docker build . -t axisecp/docker-acap:latest 
+## Building (default architecture)
+
+    docker build . -t axisecp/docker-acap:latest
+
+### armv7hf
+
+    docker build --build-arg ACAPARCH=armv7hf . -t axisecp/docker-acap:latest
+
+### aarch64
+
+    docker build --build-arg ACAPARCH=aarch64 . -t axisecp/docker-acap:latest
 
 ## Installing
 


### PR DESCRIPTION
There is no need to have two different Dockerfiles when the only
difference is the architecture of the base container. Better to set
that as a build argument.
