### PR TITLE
Make sure we don't ignore build hook file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+build/
 dockerd
 docker-proxy
 dockerdwrapper


### PR DESCRIPTION
The "build" entry in .gitignore also ignored hooks/build. We only
want to ignore the build/ folder, not the hooks/build file.