### PR TITLE
README.md: Use cleaner commandline for compatibility check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Docker ACAP requires a container capable device. You may check the compatibi
 by running:
 
 ```sh
-ssh root@<axis_device_ip> "if command -v containerd >/dev/null 2>&1; then echo "Compatible with Docker ACAP"; else echo "Not compatible with Docker ACAP"; fi"
+ssh root@<axis_device_ip> 'command -v containerd >/dev/null 2>&1 && echo Compatible with Docker ACAP || echo Not compatible with Docker ACAP'
 ```
 
 ## Installing


### PR DESCRIPTION
Single quotes are the choice for static strings in shell(scripts).
Also simplified the command line to be shorter and more efficient.
