### PR TITLE
Don't strip the built docker binaries

### DIFF
--- a/Dockerfile.dockerd
+++ b/Dockerfile.dockerd
@@ -15,8 +15,6 @@ COPY 0001-Use-stretch-as-base-to-work-on-ARTPEC-6-7.patch .
 # Install the packages we use
 RUN apk add --update \
     bash \
-    binutils-aarch64-none-elf \
-    binutils-arm-none-eabi \
     curl \
     git \
     make \
@@ -24,8 +22,6 @@ RUN apk add --update \
 
 # Setup the environment
 ARG ACAPARCH=armv7hf
-ARG STRIP=arm-none-eabi-strip
 ENV ARCH ${ACAPARCH}
-ENV STRIP ${STRIP}
 
 ENTRYPOINT [ "make", "-f", "Makefile.dockerd" ] 

--- a/Makefile.dockerd
+++ b/Makefile.dockerd
@@ -9,7 +9,6 @@ else
 endif
 
 all: dockerd
-	$(STRIP) dockerd
 
 moby-$(DOCKERVERSION):
 	curl -L https://github.com/moby/moby/archive/refs/tags/v$(DOCKERVERSION).tar.gz | tar xz && \

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 case "$1" in
-    armv7hf)
-       strip=arm-none-eabi-strip
-       ;;
-    aarch64)
-       strip=aarch64-none-elf-strip
+    armv7hf|aarch64)
        ;;
     *)
        # error
@@ -20,7 +16,6 @@ dockerdname=dockerd_name
 
 # First we build and copy out dockerd
 docker build --build-arg ACAPARCH="$1" \
-             --build-arg STRIP=$strip \
              --build-arg HTTP_PROXY \
              --build-arg HTTPS_PROXY \
              --tag $dockerdtag \


### PR DESCRIPTION
The moby developers strongly recommends not stripping the binaries, see
https://github.com/moby/moby/blob/master/project/PACKAGERS.md#stripping-binaries
for more information