### PR TITLE
Moving exec-root to tmpfs

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -338,9 +338,8 @@ start_dockerd(void)
   }
 
   if (use_sdcard) {
-    args_offset += g_snprintf(args + args_offset, args_len - args_offset, " %s %s",
-        "--data-root /var/spool/storage/SD_DISK/dockerd/data",
-        "--exec-root /var/spool/storage/SD_DISK/dockerd/exec");
+    args_offset += g_snprintf(args + args_offset, args_len - args_offset, " %s",
+        "--data-root /var/spool/storage/SD_DISK/dockerd/data");
 
     g_strlcat (msg, " using SD card as storage", msg_len);
   } else {


### PR DESCRIPTION
The exec-root have to be located on tmpfs as it needs to be wiped on reboot, see:
https://github.com/docker/for-linux/issues/809#issuecomment-769455059
It is no problem to place exec-root on the default location (/var/run/docker) as only execution state is stored there, which does not take up much space.