### PR TITLE
Update README.md with SD Card specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,9 @@ It might be necessary to reformat the SD card to one of these file systems, for
 example if the original file system of the SD card is vfat.
 
 Make sure to use an SD card that has enough capacity to hold your applications.
-Other properties of the SD card, like the speed, might affect the performance of your
-applications. For example, the
-[object-detector-python](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python)
-CV SDK example has a reasonably higher inference time when using a small and slow SD card.
+Other properties of the SD card, like the speed, might also affect the performance of your
+applications. For example, the Computer Vision SDK example
+[object-detector-python](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python) has a significantly higher inference time when using a small and slow SD card.
 To get more informed about specifications, check the
 [SD Card Standards](https://www.sdcard.org/developers/sd-standard-overview/).
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ file system. Examples of file systems which support this are ext4, ext3 and xfs.
 It might be necessary to reformat the SD card to one of these file systems, for
 example if the original file system of the SD card is vfat.
 
+Make sure to use an SD card that has enough capacity to hold your applications.
+Other properties of the SD card, like the speed, might affect the performance of your
+applications. For example, the
+[object-detector-python](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python)
+CV SDK example has a reasonably higher inference time when using a small and slow SD card.
+To get more informed about specifications, check the
+[SD Card Standards](https://www.sdcard.org/developers/sd-standard-overview/).
+
 ## Using the Docker ACAP
 
 The Docker ACAP does not contain the docker client binary. This means that all

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ example if the original file system of the SD card is vfat.
 Make sure to use an SD card that has enough capacity to hold your applications.
 Other properties of the SD card, like the speed, might also affect the performance of your
 applications. For example, the Computer Vision SDK example
-[object-detector-python](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python) has a significantly higher inference time when using a small and slow SD card.
+[object-detector-python](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python)
+has a significantly higher inference time when using a small and slow SD card.
 To get more informed about specifications, check the
 [SD Card Standards](https://www.sdcard.org/developers/sd-standard-overview/).
 


### PR DESCRIPTION
It was discovered that using an old SD card made calls to the ACAP Runtime very slow quite frequently.