### PR TITLE
build.sh: Use separate build dir for each architecture

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,4 +41,4 @@ docker build --build-arg ACAPARCH="$1" \
              --no-cache \
              --tag "$imagetag" . 
 
-docker cp "$(docker create "$imagetag")":/opt/app/ ./build
+docker cp "$(docker create "$imagetag")":/opt/app/ ./build-$1


### PR DESCRIPTION
### Describe your changes

With the single build dir `build`, it doesn't work very well to build more than one architecture in the tree without cleaning it.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
