### PR TITLE
Add architecture to manifest.json

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,12 @@ docker stop $dockerdname
 docker rm $dockerdname
 
 # Now build and copy out the acap
+
+# update the manifest.json file to list the correct architecture
+jq --arg arch "$1" '.acapPackageConf.setup.architecture = $arch' \
+app/manifest.json > manifest_file.tmp
+mv manifest_file.tmp app/manifest.json
+
 docker buildx build --build-arg ACAPARCH="$1" \
              --build-arg HTTP_PROXY="$HTTP_PROXY" \
              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \


### PR DESCRIPTION
### Describe your changes

Update of build.sh to add architecture to manifest.json before ACAP build. 
ACAP Portal requires  architecture to be listed to do signing.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
