### PR TITLE
build.sh: Stop at errors and/or unset parameters

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,16 @@
-#!/bin/sh
-case "$1" in
+#!/bin/sh -eu
+case "${1:-}" in
     armv7hf|aarch64)
        ;;
     *)
        # error
-       echo "Invalid argument '$1', valid arguments are armv7hf or aarch64"
+       echo "Invalid argument '${1:-}', valid arguments are armv7hf or aarch64"
        exit 1
        ;;
 esac
 
 dockerdtag=dockerd:1.0
-imagetag="${2:-docker-acap:1.0}"
+imagetag=${2:-docker-acap:1.0}
 dockerdname=dockerd_name
 
 # First we build and copy out dockerd


### PR DESCRIPTION
### Describe your changes

Unless we stop at errors, the script will keep going on with new commands even if the previous ones fail. It should fail early to make the build process more solid and comprehensible.

Also fail at unset parameters, and remove superfluous quotes at variable assignment.

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
