### PR TITLE
Use super-linter/super-linter and activate clang validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           LINTER_RULES_PATH: /
           IGNORE_GITIGNORED_FILES: true
           VALIDATE_BASH: true
-          VALIDATE_CLANG: true
+          VALIDATE_CLANG_FORMAT: true
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_MARKDOWN: true
           VALIDATE_SHELL_SHFMT: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint codebase
-        uses: github/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -24,6 +24,7 @@ jobs:
           LINTER_RULES_PATH: /
           IGNORE_GITIGNORED_FILES: true
           VALIDATE_BASH: true
+          VALIDATE_CLANG: true
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_MARKDOWN: true
           VALIDATE_SHELL_SHFMT: true


### PR DESCRIPTION
### Describe your changes

- Super Linter has moved from GitHub organization to super-linter and since it has now a verified creator badge we should use the path to the new repo
- Added validation of clang formatting in the linting

