### PR TITLE
Fail postinstall script with EX_NOPERM if not root

### DIFF
--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
-# *** root user required ****
-# TODO Add a check of who the user is and log warning if not root
+if [ "$(id -un)" != "root" ]; then
+    logger -p user.warn "$0: Must be run as 'root' instead of user '$(id -un)'."
+    exit 77 # EX_NOPERM
+fi
 
 # Get name and uid of acap user and group
 _appname=dockerdwrapper


### PR DESCRIPTION
This will signal acapctl to stop and fail the installation process.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
