### PR TITLE
Added sub-groups for the ACAP user

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,10 @@ file. When running a container a user called `root`, (uid 0), belonging to group
 will be the default user inside the container. It will be mapped to the non-root user on
 the device, and the group will be mapped to the non-root users primary group.
 In order to get access inside the container to resources on the device that are group owned by any
-of the non-root users secondary groups these need to be added for the container user.
+of the non-root users secondary groups, these need to be added for the container user.
 This can be done by using `group_add` in a docker-compose.yaml (`--group-add` if using Docker cli).
-Unfortunately, adding the names of the secondary groups are not supported, instead the *mapped* ids
-of the groups need to be used. At the moment of writing this the mappings are
+Unfortunately, adding the name of a secondary group is not supported. Instead the *mapped* id
+of the group need to be used. At the moment of writing this the mappings are:
 
 | device group | container group id |
 | ------------ | ------------------ |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ device.
 > * Only uid and gid are properly mapped between device and containers, not the other groups that
 > the user is a member of. This means that resources on the device, even if they are volume or device
 > mounted can be inaccessible inside the container. This can also affect usage of unsupported dbus
->  methods from the container.
+>  methods from the container. See [Using host user secondary groups in container](#using-host-user-secondary-groups-in-container)
+> for how to handle this.
 > * iptables use is disabled.
 
 <!-- omit in toc -->
@@ -294,6 +295,30 @@ and `load` can be used.
 ```sh
 docker save <image on host local repository> | docker --tlsverify --host tcp://$DEVICE_IP:$DOCKER_PORT load
 ```
+
+#### Using host user secondary groups in container
+
+The Docker Compose ACAP is run by a non-root user on the device. This user is set
+up to be a member in a number of secondary groups as listed in the
+[manifest.json](https://github.com/AxisCommunications/docker-compose-acap/blob/rootless-preview/app/manifest.json#L6-L11)
+file. When running a container a user called `root`, (uid 0), belonging to group `root`, (gid 0)
+will be the default user inside the container. It will be mapped to the non-root user on
+the device, and the group will be mapped to the non-root users primary group.
+In order to get access inside the container to resources on the device that are group owned by any
+of the non-root users secondary groups these need to be added for the container user.
+This can be done by using `group_add` in a docker-compose.yaml (`--group-add` if using Docker cli).
+Unfortunately, adding the names of the secondary groups are not supported, instead the *mapped* ids
+of the groups need to be used. At the moment of writing this the mappings are
+
+| device group | container group id |
+| ------------ | ------------------ |
+| datacache    | "1"                |
+| sdk          | "2"                |
+| storage      | "3"                |
+| vdo          | "4"                |
+| optics       | "5"                |
+
+Note that the names of the groups will not be correctly displayed inside the container.
 
 ## Building the Docker ACAP
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -4,6 +4,8 @@
         "linux": {
             "user": {
                 "groups": [
+                    "datacache",
+                    "optics",
                     "sdk",
                     "storage",
                     "vdo"
@@ -20,7 +22,7 @@
             "embeddedSdkVersion": "3.0",
             "vendorUrl": "https://www.axis.com",
             "runMode": "once",
-            "version": "2.0.0-preview"
+            "version": "2.0.1-preview"
         },
         "installation": {
             "postInstallScript": "postinstallscript.sh"

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -9,10 +9,10 @@ fi
 _appname=dockerdwrapper
 _appdirectory=/usr/local/packages/$_appname
 _uname="$(stat -c '%U' "$_appdirectory")"
-_uid="$(id "$_uname" -u)"
-_gid="$(id "$_uname" -g)"
-_gname="$(id "$_uname" -gn)"
-_grpsid="$(id "$_uname" -G)"
+_uid="$(id "$_uname" -u)"       # user id
+_gid="$(id "$_uname" -g)"       # user group id
+_gname="$(id "$_uname" -gn)"    # user group name
+_all_gids="$(id "$_uname" -G)"  # user sub-group ids
 
 # If the device supports cgroups v2 we need to start the user.service
 if [ ! -d /sys/fs/cgroup/unified ]; then
@@ -29,11 +29,11 @@ Wants=acap-user@$_uid.service" >> /etc/systemd/system/sdkdockerdwrapper.service
 
 fi
 
-# Create mapping for subuid and subgid - both shall use user id!
+# Create mapping for subuid and subgid - both shall use user id as first value!
 echo "$_uid:100000:65536" >> /etc/subuid
-for gid in $_grpsid ; do
-    if [ "$gid" -ne "$_gid" ]; then
-        echo "$_uid:$gid:1" >> /etc/subgid
+for sub_group_id in $_all_gids ; do
+    if [ "$sub_group_id" -ne "$_gid" ]; then
+        echo "$_uid:$sub_group_id:1" >> /etc/subgid
     fi
 done
 echo "$_uid:100000:65536" >> /etc/subgid

--- a/app/preuninstallscript.sh
+++ b/app/preuninstallscript.sh
@@ -19,5 +19,6 @@ rm -Rf /etc/systemd/system/acap-user-runtime-dir@.service
 rm -Rf /etc/systemd/system/acap-user@.service
 
 # Remove the subuid/subgid mappings
-sed -i "/$_uname:100000:65536/d" /etc/subuid
-sed -i "/$_uname:100000:65536/d" /etc/subgid
+# TODO - remove any mapping conaining _uid
+sed -i "/$_uid/d" /etc/subuid
+sed -i "/$_uid/d" /etc/subgid

--- a/app/preuninstallscript.sh
+++ b/app/preuninstallscript.sh
@@ -19,6 +19,5 @@ rm -Rf /etc/systemd/system/acap-user-runtime-dir@.service
 rm -Rf /etc/systemd/system/acap-user@.service
 
 # Remove the subuid/subgid mappings
-# TODO - remove any mapping conaining _uid
 sed -i "/$_uid/d" /etc/subuid
 sed -i "/$_uid/d" /etc/subgid


### PR DESCRIPTION
Allows user sub-groups to be mapped to containers.
NB! If a container needs sub-group access it has to use the group-add flag. The sub-group ids will be stated in /proc/<dockerd-pid>/gid_map

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
