### PR TITLE
Add note about root requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ it is required to also have [Buildx](https://docs.docker.com/build/install-build
 The Docker ACAP application is available as a **signed** eap-file in [Releases][latest-releases].
 
 > [!IMPORTANT]
-> From AXIS OS 11.8 `root` user is not allowed by default and in 12.0 it will removed. 
+> From AXIS OS 11.8 `root` user is not allowed by default and in 12.0 it will removed. Read more on the [Developer Community](https://www.axis.com/developer-community/news/axis-os-root-acap-signing). \
 > Docker ACAP 1.X requires root and work is ongoing to create a version that does not.
 > Meanwhile, the solution is to allow root to be able to install the Docker ACAP.
 >

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ it is required to also have [Buildx](https://docs.docker.com/build/install-build
 The Docker ACAP application is available as a **signed** eap-file in [Releases][latest-releases].
 
 > [!IMPORTANT]
-> From AXIS OS 11.8 `root` user is not allowed by default and in 12.0 it will removed. Read more on the [Developer Community](https://www.axis.com/developer-community/news/axis-os-root-acap-signing). \
+> From AXIS OS 11.8 `root` user is not allowed by default and in 12.0 it will be disallowed completely. Read more on the [Developer Community](https://www.axis.com/developer-community/news/axis-os-root-acap-signing). \
 > Docker ACAP 1.X requires root and work is ongoing to create a version that does not.
 > Meanwhile, the solution is to allow root to be able to install the Docker ACAP.
 >

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ it is required to also have [Buildx](https://docs.docker.com/build/install-build
 
 The Docker ACAP application is available as a **signed** eap-file in [Releases][latest-releases].
 
+> [!IMPORTANT]  
+> On the Apps page it is required to toggle on `Allow root-privileged apps` to be able to install the Docker ACAP
+> In the Settings -> Account page, under SSH accounts it is also required to toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the root SSH user. 
+
 The prebuilt Docker ACAP application is signed, read more about signing [here][signing-documentation].
 
 Install and use any image from [prereleases or releases][all-releases] with

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Docker ACAP application is available as a **signed** eap-file in [Releases][
 > Meanwhile, the solution is to allow root to be able to install the Docker ACAP.
 >
 > On the web page of the device:
-> 1. Go Apps page, toggle on `Allow root-privileged apps`.
+> 1. Go to the Apps page, toggle on `Allow root-privileged apps`.
 > 1. Go to System -> Account page, under SSH accounts toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the `root` SSH user.
 
 The prebuilt Docker ACAP application is signed, read more about signing [here][signing-documentation].

--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ it is required to also have [Buildx](https://docs.docker.com/build/install-build
 The Docker ACAP application is available as a **signed** eap-file in [Releases][latest-releases].
 
 > [!IMPORTANT]
-> On the Apps page it is required to toggle on `Allow root-privileged apps` to be able to install the Docker ACAP
-> In the Settings -> Account page, under SSH accounts it is also required to toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the root SSH user.
+> From AXIS OS 11.8 `root` user is not allowed by default and in 12.0 it will removed. 
+> Docker ACAP 1.X requires root and work is ongoing to create a version that does not.
+> Meanwhile, the solution is to allow root to be able to install the Docker ACAP.
+>
+> On the web page of the device:
+> 1. Go Apps page, toggle on `Allow root-privileged apps`.
+> 1. Go to System -> Account page, under SSH accounts toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the `root` SSH user.
 
 The prebuilt Docker ACAP application is signed, read more about signing [here][signing-documentation].
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ it is required to also have [Buildx](https://docs.docker.com/build/install-build
 
 The Docker ACAP application is available as a **signed** eap-file in [Releases][latest-releases].
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > On the Apps page it is required to toggle on `Allow root-privileged apps` to be able to install the Docker ACAP
-> In the Settings -> Account page, under SSH accounts it is also required to toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the root SSH user. 
+> In the Settings -> Account page, under SSH accounts it is also required to toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the root SSH user.
 
 The prebuilt Docker ACAP application is signed, read more about signing [here][signing-documentation].
 


### PR DESCRIPTION
### Describe your changes

Adding a message to inform that it is required to have root allowed to install docker acap
