### PR TITLE
set path for internal storage

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -419,13 +419,13 @@ start_dockerd(void)
     g_strlcat(msg, " in unsecured mode", msg_len);
   }
 
-  if (use_sdcard) {
-    args_offset +=
-        g_snprintf(args + args_offset,
-                   args_len - args_offset,
-                   " %s",
-                   "--data-root /var/spool/storage/SD_DISK/dockerd/data");
+  const char *data_root =
+      use_sdcard ? "/var/spool/storage/SD_DISK/dockerd/data" :
+                   "/usr/local/packages/dockerdwrapper/localdata/data";
+  args_offset += g_snprintf(
+      args + args_offset, args_len - args_offset, " --data-root %s", data_root);
 
+  if (use_sdcard) {
     g_strlcat(msg, " using SD card as storage", msg_len);
   } else {
     g_strlcat(msg, " using internal storage", msg_len);


### PR DESCRIPTION
### Describe your changes

The default path when data-root is not set creates a .local folder in /usr/local/packages/dockerdwrapper. This change sets it instead to /usr/local/packages/dockerdwrapper/localdata/data 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
