### PR TITLE
Use AxParameter library from native SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,11 @@ ARG DOCKER_IMAGE_VERSION=24.0.2
 ARG REPO=axisecp
 ARG ACAPARCH=armv7hf
 
-ARG VERSION=1.3
+ARG VERSION=1.13
 ARG UBUNTU_VERSION=22.04
 ARG NATIVE_SDK=acap-native-sdk
 
-ARG ACAP3_SDK_VERSION=3.5
-ARG ACAP3_UBUNTU_VERSION=20.04
-ARG ACAP3_SDK=acap-sdk
-
 FROM ${REPO}/${NATIVE_SDK}:${VERSION}-${ACAPARCH}-ubuntu${UBUNTU_VERSION} as build_image
-
-FROM ${REPO}/${ACAP3_SDK}:${ACAP3_SDK_VERSION}-${ACAPARCH}-ubuntu${ACAP3_UBUNTU_VERSION} as acap-sdk
 
 FROM build_image AS ps
 ARG PROCPS_VERSION=v3.3.17
@@ -59,13 +53,6 @@ ARG DOCKER_IMAGE_VERSION
 ENV DOCKERVERSION ${DOCKER_IMAGE_VERSION}
 ARG ACAPARCH
 ENV ARCH ${ACAPARCH}
-
-# Copy over axparameter from the acap-sdk
-COPY --from=acap-sdk /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/include/axsdk/ax_parameter /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/include/axsdk
-COPY --from=acap-sdk /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so
-COPY --from=acap-sdk /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so.1 /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so.1
-COPY --from=acap-sdk /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so.1.0 /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/libaxparameter.so.1.0
-COPY --from=acap-sdk /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/pkgconfig/axparameter.pc /opt/axis/acapsdk/sysroots/${ACAPARCH}/usr/lib/pkgconfig/axparameter.pc
 
 COPY app /opt/app
 COPY --from=ps /export/ps /opt/app

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-#include <axsdk/ax_parameter.h>
+#include <axsdk/axparameter.h>
 #include <errno.h>
 #include <glib.h>
 #include <mntent.h>
@@ -553,7 +553,7 @@ dockerd_process_exited_callback(__attribute__((unused)) GPid pid,
                                 __attribute__((unused)) gpointer user_data)
 {
   GError *error = NULL;
-  if (!g_spawn_check_exit_status(status, &error)) {
+  if (!g_spawn_check_wait_status(status, &error)) {
     syslog(LOG_ERR, "Dockerd process exited with error: %d", status);
     g_clear_error(&error);
 


### PR DESCRIPTION
### Describe your changes

- Using axparameter library from ACAP native SDK.
- Removing g_spawn_check_exit_status() since its deprecated and using the recommended g_spawn_check_wait_status().

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
