### PR TITLE
Add a new parameter to have an option to choose TCP socket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The Docker ACAP application is available as a **signed** eap-file in [Releases][
 > Meanwhile, the solution is to allow root to be able to install the Docker ACAP.
 >
 > On the web page of the device:
+>
 > 1. Go to the Apps page, toggle on `Allow root-privileged apps`.
 > 1. Go to System -> Account page, under SSH accounts toggle off `Restrict root access` to be able to send the TLS certificates. Make sure to set the password of the `root` SSH user.
 
@@ -73,16 +74,15 @@ It's also possible to build and use a locally built image. See the
 ## Securing the Docker ACAP using TLS
 
 The Docker Compose ACAP application can be run in either TLS mode or unsecured mode. The Docker Compose
-ACAP application uses unsecured mode by default. These modes can be used with or without TCP and IPC
-sockets. There is an option to choose between "TCPSocket" and "IPCSocket" socket parameters. It should
-be noted that if TCP and IPC sockets are not enabled, Dockerd will not start.
+ACAP application uses TLS mode by default. These modes can be used with or without TCP and IPC sockets.
+It should be noted that if TCP and IPC sockets are not enabled, Dockerd will not start.
 
-Use the "Use TLS", "TCP Socket" and "IPC Socket" dropdowns in the web interface to switch between the
+Use the "Use TLS" and "TCP Socket" dropdowns in the web interface to switch between the
 two different modes(yes/no). Whenever these settings change, the Docker daemon will automatically restart.
 It's also possible to toggle this option by calling the parameter management API in
-[VAPIX](https://www.axis.com/vapix-library/) and setting `root.dockerdwrapperwithcompose.UseTLS`,
-`root.dockerdwrapperwithcompose.TCPSocket` and `root.dockerdwrapperwithcompose.IPCSocket` parameters
-to `yes` or `no`. The following commands would enable those parameters:
+[VAPIX](https://www.axis.com/vapix-library/) and setting `root.dockerdwrapperwithcompose.UseTLS` and
+`root.dockerdwrapperwithcompose.TCPSocket` parameters to `yes` or `no`.
+The following commands would enable those parameters:
 
 ```sh
 DEVICE_IP=<device ip>
@@ -101,13 +101,6 @@ Enable TCP Socket:
 ```sh
 curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
   "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapperwithcompose.TCPSocket=yes"
-```
-
-Enable IPC Socket:
-
-```sh
-curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
-  "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapperwithcompose.IPCSocket=yes"
 ```
 
 Note that the dockerd service will be restarted every time TLS is activated or
@@ -238,6 +231,7 @@ docker buildx build --file Dockerfile --tag docker-acap:<ARCH> --build-arg ACAPA
 where `<ARCH>` is either `armv7hf` or `aarch64`.
 
 To extract the Docker ACAP eap-file use docker cp to copy it to a `build` folder:
+
 ```sh
 docker cp "$(docker create "docker-acap:<ARCH>")":/opt/app/ ./build
 ```

--- a/README.md
+++ b/README.md
@@ -72,18 +72,42 @@ It's also possible to build and use a locally built image. See the
 
 ## Securing the Docker ACAP using TLS
 
-The Docker ACAP can be run either unsecured or in TLS mode. The Docker ACAP uses
-TLS as default. Use the "Use TLS" dropdown in the web interface to switch
-between the two different modes. It's also possible to toggle this option by
-calling the parameter management API in [VAPIX](https://www.axis.com/vapix-library/) and setting the
-`root.dockerdwrapper.UseTLS` parameter to `yes` or `no`. The following commands would enable TLS:
+The Docker Compose ACAP application can be run in either TLS mode or unsecured mode. The Docker Compose
+ACAP application uses unsecured mode by default. These modes can be used with or without TCP and IPC
+sockets. There is an option to choose between "TCPSocket" and "IPCSocket" socket parameters. It should
+be noted that if TCP and IPC sockets are not enabled, Dockerd will not start.
+
+Use the "Use TLS", "TCP Socket" and "IPC Socket" dropdowns in the web interface to switch between the
+two different modes(yes/no). Whenever these settings change, the Docker daemon will automatically restart.
+It's also possible to toggle this option by calling the parameter management API in
+[VAPIX](https://www.axis.com/vapix-library/) and setting `root.dockerdwrapperwithcompose.UseTLS`,
+`root.dockerdwrapperwithcompose.TCPSocket` and `root.dockerdwrapperwithcompose.IPCSocket` parameters
+to `yes` or `no`. The following commands would enable those parameters:
 
 ```sh
 DEVICE_IP=<device ip>
 DEVICE_PASSWORD='<password>'
+```
 
+Enable TLS:
+
+```sh
 curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
   "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapper.UseTLS=yes"
+```
+
+Enable TCP Socket:
+
+```sh
+curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
+  "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapperwithcompose.TCPSocket=yes"
+```
+
+Enable IPC Socket:
+
+```sh
+curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
+  "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapperwithcompose.IPCSocket=yes"
 ```
 
 Note that the dockerd service will be restarted every time TLS is activated or

--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ It's also possible to build and use a locally built image. See the
 ## Securing the Docker ACAP using TLS
 
 The Docker Compose ACAP application can be run in either TLS mode or unsecured mode. The Docker Compose
-ACAP application uses TLS mode by default. These modes can be used with or without TCP and IPC sockets.
-It is important to note that Dockerd will fail to start if TCP socket or IPC socket parameters are not
-selected, one of these sockets must be set to `yes`.
+ACAP application uses TLS mode by default. It is important to note that Dockerd will fail to start if
+TCP socket or IPC socket parameters are not selected, one of these sockets must be set to `yes`.
 
 Use the "Use TLS" and "TCP Socket" dropdowns in the web interface to switch between the
 two different modes(yes/no). Whenever these settings change, the Docker daemon will automatically restart.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ It's also possible to build and use a locally built image. See the
 
 The Docker Compose ACAP application can be run in either TLS mode or unsecured mode. The Docker Compose
 ACAP application uses TLS mode by default. These modes can be used with or without TCP and IPC sockets.
-It should be noted that if TCP and IPC sockets are not enabled, Dockerd will not start.
+It is important to note that Dockerd will fail to start if TCP socket or IPC socket parameters are not
+selected, one of these sockets must be set to `yes`.
 
 Use the "Use TLS" and "TCP Socket" dropdowns in the web interface to switch between the
 two different modes(yes/no). Whenever these settings change, the Docker daemon will automatically restart.
@@ -218,6 +219,10 @@ docker -H=<device ip>:$DOCKER_INSECURE_PORT version
 See [Client key and certificate](#client-key-and-certificate) for an example
 of how to remotely run docker commands on a device running a secured Docker ACAP
 using TLS.
+
+The application can provide a TCP socket if the TCP Socket setting is set to `yes` and an IPC socket
+if the IPC Socket setting is set to `yes`. Please be aware that at least one of these sockets must be
+selected for the application to start.
 
 ## Building the Docker ACAP
 

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -56,7 +56,10 @@ static const char *dockerd_path_on_sd_card =
 static bool restart_dockerd = false;
 
 // All ax_parameters the acap has
-static const char *ax_parameters[] = {"IPCSocket", "SDCardSupport", "UseTLS"};
+static const char *ax_parameters[] = {"IPCSocket",
+                                      "SDCardSupport",
+                                      "TCPSocket",
+                                      "UseTLS"};
 
 static const char *tls_cert_path = "/usr/local/packages/dockerdwrapper/";
 

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -478,6 +478,7 @@ start_dockerd(const struct settings *settings)
     args_offset += g_snprintf(args + args_offset,
                               args_len - args_offset,
                               " -H unix:///var/run/docker.sock");
+    g_strlcat(msg, " with IPC socket.", msg_len);
   } else {
     g_strlcat(msg, " without IPC socket.", msg_len);
   }

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -434,12 +434,14 @@ start_dockerd(const struct settings *settings)
     goto end;
   }
 
-  if (use_tls) {
-    const char *ca_path = "/usr/local/packages/dockerdwrapper/ca.pem";
-    const char *cert_path =
-        "/usr/local/packages/dockerdwrapper/server-cert.pem";
-    const char *key_path = "/usr/local/packages/dockerdwrapper/server-key.pem";
-    if (use_tcp_socket) {
+  if (use_tcp_socket) {
+    if (use_tls) {
+      const char *ca_path = "/usr/local/packages/dockerdwrapper/ca.pem";
+      const char *cert_path =
+          "/usr/local/packages/dockerdwrapper/server-cert.pem";
+      const char *key_path =
+          "/usr/local/packages/dockerdwrapper/server-key.pem";
+
       args_offset += g_snprintf(args + args_offset,
                                 args_len - args_offset,
                                 " %s %s %s %s %s %s %s %s",
@@ -453,15 +455,15 @@ start_dockerd(const struct settings *settings)
                                 key_path);
 
       g_strlcat(msg, " in TLS mode with TCP socket", msg_len);
-    }
-  } else if (use_tcp_socket && !use_tls) {
-    args_offset += g_snprintf(args + args_offset,
-                              args_len - args_offset,
-                              " %s %s",
-                              "-H tcp://0.0.0.0:2375",
-                              "--tls=false");
+    } else {
+      args_offset += g_snprintf(args + args_offset,
+                                args_len - args_offset,
+                                " %s %s",
+                                "-H tcp://0.0.0.0:2375",
+                                "--tls=false");
 
-    g_strlcat(msg, " in unsecured mode with TCP socket", msg_len);
+      g_strlcat(msg, " in unsecured mode with TCP socket", msg_len);
+    }
   }
 
   g_autofree char *data_root_msg = g_strdup_printf(
@@ -478,7 +480,6 @@ start_dockerd(const struct settings *settings)
     args_offset += g_snprintf(args + args_offset,
                               args_len - args_offset,
                               " -H unix:///var/run/docker.sock");
-    g_strlcat(msg, " with IPC socket.", msg_len);
   } else {
     g_strlcat(msg, " without IPC socket.", msg_len);
   }

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -464,6 +464,8 @@ start_dockerd(const struct settings *settings)
 
       g_strlcat(msg, " in unsecured mode with TCP socket", msg_len);
     }
+  } else {
+    g_strlcat(msg, " in unsecured mode", msg_len);
   }
 
   g_autofree char *data_root_msg = g_strdup_printf(

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -473,7 +473,7 @@ start_dockerd(const struct settings *settings)
       g_strlcat(msg, " in unsecured mode", msg_len);
     }
   } else {
-    g_strlcat(msg, " without TCP socket in unsecured mode", msg_len);
+    g_strlcat(msg, " without TCP socket", msg_len);
   }
 
   g_autofree char *data_root_msg = g_strdup_printf(

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -357,7 +357,7 @@ end:
 static gboolean
 get_tcp_socket_selection(bool *use_tcp_socket_ret)
 {
-  *use_tcp_socket_ret = get_parameter_value("TCPSocket");
+  *use_tcp_socket_ret = is_parameter_yes("TCPSocket");
   return true;
 }
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -27,12 +27,17 @@
                 },
                 {
                     "name": "UseTLS",
-                    "default": "yes",
+                    "default": "no",
+                    "type": "enum:no|No, yes|Yes"
+                },
+                {
+                    "name": "TCPSocket",
+                    "default": "no",
                     "type": "enum:no|No, yes|Yes"
                 },
                 {
                     "name": "IPCSocket",
-                    "default": "no",
+                    "default": "yes",
                     "type": "enum:no|No, yes|Yes"
                 }
             ]

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -27,12 +27,12 @@
                 },
                 {
                     "name": "UseTLS",
-                    "default": "no",
+                    "default": "yes",
                     "type": "enum:no|No, yes|Yes"
                 },
                 {
                     "name": "TCPSocket",
-                    "default": "no",
+                    "default": "yes",
                     "type": "enum:no|No, yes|Yes"
                 },
                 {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -37,7 +37,7 @@
                 },
                 {
                     "name": "IPCSocket",
-                    "default": "yes",
+                    "default": "no",
                     "type": "enum:no|No, yes|Yes"
                 }
             ]


### PR DESCRIPTION
### Describe your changes

Adding option to toggle use of TCP socket, default set to "yes".
At least one of the sockets need to be selected for dockerd to be started.

### Issue ticket number and link

Fixes #126

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
