### PR TITLE
Migrate data root

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -16,11 +16,15 @@
 
 #include <axsdk/axparameter.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <ftw.h>
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <mntent.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <sysexits.h>
 #include <syslog.h>
@@ -169,6 +173,65 @@ end:
 }
 
 /**
+ * @brief Migrate the contents of the data directory from the old setup on the
+ * SD card to 'new_dir' The new directory must be created and empty. If the
+ * operation is successful, the old setup directory will be removed.
+ *
+ * @return True if operation was successful, false otherwise.
+ */
+static bool
+migrate_from_old_sdcard_setup(const char *new_dir)
+{
+  const char *old_top_dir = "/var/spool/storage/SD_DISK/dockerd";
+  struct stat directory_stat;
+  int stat_result = stat(old_top_dir, &directory_stat);
+  if (stat(old_top_dir, &directory_stat) != 0) {
+    // No files to move
+    return true;
+  }
+
+  // The new directory must be created and empty.
+  GDir *dir = g_dir_open(new_dir, 0, NULL);
+  if (dir == NULL) {
+    syslog(LOG_ERR, "Failed to open %s", new_dir);
+    return false;
+  }
+  // Get name to first entry in directory, NULL if empty, . and .. are omitted
+  const char *dir_entry = g_dir_read_name(dir);
+  g_dir_close(dir);
+
+  if (dir_entry != NULL) {
+    syslog(LOG_ERR,
+           "Target directory %s is not empty. Can't move files.",
+           new_dir);
+    return false;
+  }
+
+  // Move data from the old directory
+  const char *move_command =
+      g_strdup_printf("mv %s/data/* %s/.", old_top_dir, new_dir);
+  syslog(LOG_INFO, "Run move cmd: \"%s\"", move_command);
+  int res = system(move_command);
+  if (res != 0) {
+    syslog(LOG_ERR,
+           "Failed to move %s to %s, error: %d",
+           old_top_dir,
+           new_dir,
+           res);
+    return false;
+  }
+
+  // Remove the directory
+  const char *remove_command = g_strdup_printf("rm -rf %s", old_top_dir);
+  res = system(remove_command);
+  if (res != 0) {
+    syslog(LOG_ERR, "Failed to remove %s, error: %d", old_top_dir, res);
+  }
+
+  return res == 0;
+}
+
+/**
  * @brief Retrieve the file system type of the device containing this path.
  *
  * @return The file system type as a string (ext4/ext3/vfat etc...) if
@@ -263,6 +326,11 @@ setup_sdcard(const char *data_root)
            "card directory at %s. Please change the directory permissions or "
            "remove the directory.",
            data_root);
+    return false;
+  }
+
+  if (!migrate_from_old_sdcard_setup(data_root)) {
+    syslog(LOG_ERR, "Failed to migrate data from old data-root");
     return false;
   }
 

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -16,15 +16,11 @@
 
 #include <axsdk/axparameter.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <ftw.h>
 #include <glib.h>
-#include <glib/gstdio.h>
 #include <mntent.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <sysexits.h>
 #include <syslog.h>
@@ -198,11 +194,12 @@ migrate_from_old_sdcard_setup(const char *new_dir)
   }
   // Get name to first entry in directory, NULL if empty, . and .. are omitted
   const char *dir_entry = g_dir_read_name(dir);
+  bool directory_not_empty = dir_entry != NULL;
   g_dir_close(dir);
 
-  if (dir_entry != NULL) {
+  if (directory_not_empty) {
     syslog(LOG_ERR,
-           "Target directory %s is not empty. Can't move files.",
+           "Target directory %s is not empty. Will not move files.",
            new_dir);
     return false;
   }


### PR DESCRIPTION
### Describe your changes

Adding functionality that moves the contents of the data-root from the old location on the SD_Card to the new location as provided by the Axstorage setup. This is to support upgrading from  from previous releases of Docker* ACAP without losing data.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
