### PR TITLE
Remove unused error variable

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -652,6 +652,7 @@ setup_axparameter(void)
 end:
   if (!success && ax_parameter != NULL) {
     ax_parameter_free(ax_parameter);
+    ax_parameter = NULL;
   }
   return ax_parameter;
 }
@@ -659,7 +660,6 @@ end:
 int
 main(void)
 {
-  GError *error = NULL;
   AXParameter *ax_parameter = NULL;
   exit_code = 0;
 
@@ -672,7 +672,7 @@ main(void)
   // Setup ax_parameter
   ax_parameter = setup_axparameter();
   if (ax_parameter == NULL) {
-    syslog(LOG_ERR, "Error in setup_axparameter: %s", error->message);
+    syslog(LOG_ERR, "Error in setup_axparameter");
     exit_code = -1;
     goto end;
   }
@@ -708,6 +708,5 @@ end:
     ax_parameter_free(ax_parameter);
   }
 
-  g_clear_error(&error);
   return exit_code;
 }


### PR DESCRIPTION
Since 'error' is not passed in to setup_axparameter(), it will not be set in case setup_axparameter() fails. However, it wasn't possible to get setup_axparameter() to fail. Both ax_parameter_new() and ax_parameter_register_callback() are apparently valid to call even with a non-existing application name.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
