### PR TITLE
Allow more than one call to g_main_loop_run()

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -652,6 +652,7 @@ setup_axparameter(void)
 end:
   if (!success && ax_parameter != NULL) {
     ax_parameter_free(ax_parameter);
+    ax_parameter = NULL;
   }
   return ax_parameter;
 }
@@ -659,7 +660,6 @@ end:
 int
 main(void)
 {
-  GError *error = NULL;
   AXParameter *ax_parameter = NULL;
   exit_code = 0;
 
@@ -672,7 +672,7 @@ main(void)
   // Setup ax_parameter
   ax_parameter = setup_axparameter();
   if (ax_parameter == NULL) {
-    syslog(LOG_ERR, "Error in setup_axparameter: %s", error->message);
+    syslog(LOG_ERR, "Error in setup_axparameter");
     exit_code = -1;
     goto end;
   }
@@ -708,6 +708,5 @@ end:
     ax_parameter_free(ax_parameter);
   }
 
-  g_clear_error(&error);
   return exit_code;
 }


### PR DESCRIPTION
By running g_main_loop_run() in a while-loop, other parts of the program can retry starting dockerd by simply calling g_main_loop_quit(). To exit this loop, call quit_program(), which will also set the global acap_exit_code variable.

This is needed then e.g. axstorage is used to wait for SD card to become available.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
