### PR TITLE
Remove partial use of global var in is_process_alive()

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -110,7 +110,7 @@ is_process_alive(int pid)
   if (return_pid == -1) {
     // Report errors as dead.
     return false;
-  } else if (return_pid == dockerd_process_pid) {
+  } else if (return_pid == pid) {
     // Child is already exited, so not alive.
     return false;
   }


### PR DESCRIPTION
### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
