### PR TITLE
Don't start main loop if fail to start dockerd

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -277,7 +277,7 @@ is_parameter_yes(const char *name)
 // Return data root matching the current SDCardSupport selection.
 //
 // If SDCardSupport is "yes", data root will be located on the proved SD card
-// area. Passing NULL as SD card area signals that the SD card is not availble.
+// area. Passing NULL as SD card area signals that the SD card is not available.
 static char *
 prepare_data_root(const char *sd_card_area)
 {
@@ -700,10 +700,11 @@ main(void)
   while (application_exit_code == EX_KEEP_RUNNING) {
     if (dockerd_process_pid == -1 &&
         !read_settings_and_start_dockerd(&app_state))
-
       quit_program(EX_SOFTWARE);
-
-    g_main_loop_run(loop);
+    else
+    {
+      g_main_loop_run(loop);
+    }
 
     if (!stop_dockerd())
       syslog(LOG_WARNING, "Failed to shut down dockerd.");


### PR DESCRIPTION
### Describe your changes

Don't start the main loop if `read_settings_and_start_dockerd` fails

### Issue ticket number and link

- Fixes issue where application doesn't exit even though dockerd isn't started.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
