### PR TITLE
Fail installation on device without container support

### DIFF
--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
+
+if [ ! -e /usr/bin/containerd ]; then
+	logger -p user.warn "$0: Container support required to install application."
+	exit 77 # EX_NOPERM
+fi
 
 # Move the daemon.json file into localdata folder
 if [ ! -e localdata/daemon.json ]; then


### PR DESCRIPTION
### Describe your changes

Use the postinstall script to fail installation on devices that does not have container support.

### Issue ticket number and link

- Fixes #65

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
