### PR TITLE
Parameters as bool instead of enum

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -23,22 +23,22 @@
         {
           "name": "SDCardSupport",
           "default": "no",
-          "type": "enum:no|No, yes|Yes"
+          "type": "bool:no,yes"
         },
         {
           "name": "UseTLS",
           "default": "yes",
-          "type": "enum:no|No, yes|Yes"
+          "type": "bool:no,yes"
         },
         {
           "name": "TCPSocket",
           "default": "yes",
-          "type": "enum:no|No, yes|Yes"
+          "type": "bool:no,yes"
         },
         {
           "name": "IPCSocket",
           "default": "no",
-          "type": "enum:no|No, yes|Yes"
+          "type": "bool:no,yes"
         }
       ]
     }


### PR DESCRIPTION
### Describe your changes

All current parameters are treated as bools so we might as well use the `bool` type

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
