### PR TITLE
Allow runtime changing of application and dockerd log level

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -29,6 +29,8 @@
 #define APP_DIRECTORY "/usr/local/packages/" APP_NAME
 #define APP_LOCALDATA APP_DIRECTORY "/localdata"
 
+#define PARAM_APPLICATION_LOG_LEVEL "ApplicationLogLevel"
+#define PARAM_DOCKERD_LOG_LEVEL "DockerdLogLevel"
 #define PARAM_IPC_SOCKET "IPCSocket"
 #define PARAM_SD_CARD_SUPPORT "SDCardSupport"
 #define PARAM_TCP_SOCKET "TCPSocket"
@@ -64,7 +66,9 @@ static int application_exit_code = EX_KEEP_RUNNING;
 static pid_t dockerd_process_pid = -1;
 
 // All ax_parameters the acap has
-static const char *ax_parameters[] = {PARAM_IPC_SOCKET,
+static const char *ax_parameters[] = {PARAM_APPLICATION_LOG_LEVEL,
+                                      PARAM_DOCKERD_LOG_LEVEL,
+                                      PARAM_IPC_SOCKET,
                                       PARAM_SD_CARD_SUPPORT,
                                       PARAM_TCP_SOCKET,
                                       PARAM_USE_TLS};
@@ -328,13 +332,25 @@ setup_sdcard(const char *data_root)
   return true;
 }
 
+static bool
+is_parameter_equal_to(const char *name, const char *value_to_equal)
+{
+  g_autofree char *value = get_parameter_value(name);
+  return value && strcmp(value, value_to_equal) == 0;
+}
+
 // A parameter of type "bool:no,yes" is guaranteed to contain one of those
 // strings, but user code is still needed to interpret it as a Boolean type.
 static bool
 is_parameter_yes(const char *name)
 {
-  g_autofree char *value = get_parameter_value(name);
-  return value && strcmp(value, "yes") == 0;
+  return is_parameter_equal_to(name, "yes");
+}
+
+static bool
+is_app_log_level_debug(void)
+{
+  return is_parameter_equal_to(PARAM_APPLICATION_LOG_LEVEL, "debug");
 }
 
 // Return data root matching the current SDCardSupport selection.
@@ -466,6 +482,14 @@ start_dockerd(const struct settings *settings, struct app_state *app_state)
                             "--config-file " APP_LOCALDATA "/daemon.json");
 
   g_strlcpy(msg, "Starting dockerd", msg_len);
+
+  {
+    g_autofree char *log_level = get_parameter_value(PARAM_DOCKERD_LOG_LEVEL);
+    args_offset += g_snprintf(args + args_offset,
+                              args_len - args_offset,
+                              " --log-level=%s",
+                              log_level);
+  }
 
   if (!use_ipc_socket && !use_tcp_socket) {
     log_error(
@@ -722,6 +746,7 @@ main(int argc, char **argv)
   struct log_settings log_settings = {0};
   AXParameter *ax_parameter = NULL;
 
+  log_settings.debug = is_app_log_level_debug();
   parse_command_line(argc, argv, &log_settings);
 
   log_init(&log_settings);
@@ -746,6 +771,8 @@ main(int argc, char **argv)
       read_settings_and_start_dockerd(&app_state);
 
     g_main_loop_run(loop);
+
+    log_settings.debug = is_app_log_level_debug();
 
     if (!stop_dockerd())
       log_warning("Failed to shut down dockerd.");

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -39,6 +39,16 @@
                     "name": "IPCSocket",
                     "default": "no",
                     "type": "bool:no,yes"
+                },
+                {
+                    "name": "ApplicationLogLevel",
+                    "default": "info",
+                    "type": "enum:debug,info"
+                },
+                {
+                    "name": "DockerdLogLevel",
+                    "default": "info",
+                    "type": "enum:debug,info,warn,error,fatal"
                 }
             ]
         }


### PR DESCRIPTION
The default level (info) is the same as before.

Changing any of the log level parameters will restart dockerd.

Since the log levels are persisted as parameters,
is will be possible to debug start-up behavior,
by setting it to 'debug' before starting the application.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
