### PR TITLE
Ignore SD card state changes when not SD card is not used

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -743,10 +743,12 @@ static void
 sd_card_callback(const char *sd_card_area, void *app_state_void_ptr)
 {
   struct app_state *app_state = app_state_void_ptr;
-  if (!sd_card_area)
+  const bool using_sd_card = is_parameter_yes(PARAM_SD_CARD_SUPPORT);
+  if (using_sd_card && !sd_card_area)
     stop_dockerd(); // Block here until dockerd has stopped using the SD card.
   app_state->sd_card_area = sd_card_area ? strdup(sd_card_area) : NULL;
-  g_main_loop_quit(loop); // Trigger a restart of dockerd from main()
+  if (using_sd_card)
+    g_main_loop_quit(loop); // Trigger a restart of dockerd from main()
 }
 
 // Stop the application and start it from an SSH prompt with

--- a/app/sd_disk_storage.h
+++ b/app/sd_disk_storage.h
@@ -2,8 +2,10 @@
 
 typedef void (*SdDiskCallback)(const char *area_path, void *user_data);
 
-// Call sd_disk_callback with a path to the SD card when it has become available
-// and with NULL when it is about to be unmounted.
+// Call sd_disk_callback with a path to the SD card when it has become
+// available. Call sd_disk_callback with NULL when it is about to be unmounted.
+// Unmounting will fail if the SD card area contains open files when the
+// callback returns.
 struct sd_disk_storage *sd_disk_storage_init(SdDiskCallback sd_disk_callback,
                                              void *user_data);
 


### PR DESCRIPTION
Prevent SD card state change from restarting dockerd when SD card is not being used.

Also clarifying the comment about SD card unmounting.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
