### PR TITLE
Workflow: add flag to curl command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -172,7 +172,7 @@ jobs:
             -H 'Authorization: Bearer ${{secrets.ACAP_PORTAL_SIGNING_BEARER_TOKEN}}' \
             '${{ vars.ACAP_PORTAL_URL }}/${{secrets.ACAP_PORTAL_SIGNING_ID}}/sign/binary' \
             -F uploadedFile=@"${{ env.EAP_FILE }}" --output ${{ env.SIGNED_EAP_FILE }} \
-            -w "%{http_code}\n" -o /dev/null)
+            -w "%{http_code}\n" -o /dev/null --http1.1)
           echo "HTTP_RESPONSE=$RESPONSE" >> $GITHUB_ENV
       - name: Check that acap has been signed
         run: |


### PR DESCRIPTION
As seen on docker-compose-acap the `--http1.1` flag is needed for the signing request when file sizes grow bigger.
