### PR TITLE
Make dockerd 'allow start' flag thread safe

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -71,10 +71,18 @@ struct settings {
 };
 
 struct app_state {
-    bool allow_dockerd_to_start;
+    volatile int allow_dockerd_to_start_atomic;
     char* sd_card_area;
     AXParameter* param_handle;
 };
+
+static bool dockerd_allowed_to_start(const struct app_state* app_state) {
+    return g_atomic_int_get(&app_state->allow_dockerd_to_start_atomic);
+}
+
+static void allow_dockerd_to_start(struct app_state* app_state, bool new_value) {
+    g_atomic_int_set(&app_state->allow_dockerd_to_start_atomic, new_value);
+}
 
 // If process exited by a signal, code will be -1.
 // If process exited with an exit code, signal will be 0.
@@ -670,7 +678,7 @@ static void dockerd_process_exited_callback(GPid pid, gint status, gpointer app_
     struct app_state* app_state = app_state_void_ptr;
 
     bool runtime_error = child_process_exited_with_error(status);
-    app_state->allow_dockerd_to_start = !runtime_error;
+    allow_dockerd_to_start(app_state, !runtime_error);
     status_code_t s = runtime_error ? STATUS_DOCKERD_RUNTIME_ERROR : STATUS_DOCKERD_STOPPED;
     set_status_parameter(app_state->param_handle, s);
 
@@ -706,7 +714,7 @@ parameter_changed_callback(const gchar* name, const gchar* value, gpointer app_s
     struct app_state* app_state = app_state_void_ptr;
 
     // If dockerd has failed before, this parameter change may have resolved the problem.
-    app_state->allow_dockerd_to_start = true;
+    allow_dockerd_to_start(app_state, true);
 
     // Trigger a restart of dockerd from main(), but delay it 1 second.
     // When there are multiple AXParameter callbacks in a queue, such as
@@ -781,7 +789,7 @@ int main(int argc, char** argv) {
     parse_command_line(argc, argv, &log_settings);
     log_init(&log_settings);
 
-    app_state.allow_dockerd_to_start = true;
+    allow_dockerd_to_start(&app_state, true);
 
     app_state.param_handle = setup_axparameter(&app_state);
     if (!app_state.param_handle) {
@@ -796,7 +804,7 @@ int main(int argc, char** argv) {
     struct sd_disk_storage* sd_disk_storage = sd_disk_storage_init(sd_card_callback, &app_state);
 
     while (application_exit_code == EX_KEEP_RUNNING) {
-        if (dockerd_process_pid == -1 && app_state.allow_dockerd_to_start)
+        if (dockerd_process_pid == -1 && dockerd_allowed_to_start(&app_state))
             read_settings_and_start_dockerd(&app_state);
 
         main_loop_run();


### PR DESCRIPTION
HTTP requests are handled by another thread.

A successful file upload must allow dockerd to recover.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
