### PR TITLE
Restart dockerd after successful file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ For more information on how to generate these files, please consult the official
 [Docker documentation](https://docs.docker.com/engine/security/protect-access/).
 
 The files can be uploaded to the device using HTTP.
+The dockerd service will restart, or try to start, after each HTTP POST request.
 
 ```sh
 curl --anyauth -u "root:$DEVICE_PASSWORD" -F file=@ca.pem -X POST \
@@ -143,7 +144,8 @@ curl --anyauth -u "root:$DEVICE_PASSWORD" -X DELETE \
 ```
 
 They can also be copied to the `/usr/local/packages/dockerdwrapper/localdata`
-directory of the device using `scp`.
+directory of the device using `scp`,
+but this method will not cause the dockerd service to restart.
 
 ```sh
 scp ca.pem server-cert.pem server-key.pem root@<device ip>:/usr/local/packages/dockerdwrapper/localdata/

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -774,6 +774,10 @@ static void sd_card_callback(const char* sd_card_area, void* app_state_void_ptr)
         main_loop_quit();  // Trigger a restart of dockerd from main()
 }
 
+static void restart_dockerd_after_file_upload(void) {
+    main_loop_quit();
+}
+
 // Stop the application and start it from an SSH prompt with
 // $ ./dockerdwrapper --stdout
 // in order to get log messages written to console rather than to syslog.
@@ -827,7 +831,7 @@ int main(int argc, char** argv) {
 
     init_signals();
 
-    int fcgi_error = fcgi_start(http_request_callback);
+    int fcgi_error = fcgi_start(http_request_callback, restart_dockerd_after_file_upload);
     if (fcgi_error)
         return fcgi_error;
 

--- a/app/fcgi_server.h
+++ b/app/fcgi_server.h
@@ -2,5 +2,5 @@
 
 typedef void (*fcgi_request_callback)(void* request_void_ptr, void* userdata);
 
-int fcgi_start(fcgi_request_callback request_callback);
+int fcgi_start(fcgi_request_callback request_callback, void* request_callback_parameter);
 void fcgi_stop(void);

--- a/app/http_request.c
+++ b/app/http_request.c
@@ -74,7 +74,8 @@ static void response_msg(FCGX_Request* request, const char* status, const char* 
     response(request, status, "text/plain", body);
 }
 
-static void post_request(FCGX_Request* request, const char* filename) {
+static void
+post_request(FCGX_Request* request, const char* filename, restart_dockerd_t restart_dockerd) {
     g_autofree char* temp_file = fcgi_write_file_from_stream(*request);
     if (!temp_file) {
         response_msg(request, HTTP_422_UNPROCESSABLE_CONTENT, "Upload to temporary file failed.");
@@ -82,8 +83,10 @@ static void post_request(FCGX_Request* request, const char* filename) {
     }
     if (!copy_to_localdata(temp_file, filename))
         response_msg(request, HTTP_500_INTERNAL_SERVER_ERROR, "Failed to copy file to localdata");
-    else
+    else {
         response_204_no_content(request);
+        restart_dockerd();
+    }
 
     if (unlink(temp_file) != 0)
         log_error("Failed to remove %s: %s", temp_file, strerror(errno));
@@ -110,8 +113,9 @@ static void malformed_request(FCGX_Request* request, const char* method, const c
     response_msg(request, HTTP_400_BAD_REQUEST, "Malformed request");
 }
 
-void http_request_callback(void* request_void_ptr, __attribute__((unused)) void* userdata) {
+void http_request_callback(void* request_void_ptr, void* restart_dockerd_void_ptr) {
     FCGX_Request* request = (FCGX_Request*)request_void_ptr;
+
     const char* method = FCGX_GetParam("REQUEST_METHOD", request->envp);
     const char* uri = FCGX_GetParam("REQUEST_URI", request->envp);
 
@@ -124,7 +128,7 @@ void http_request_callback(void* request_void_ptr, __attribute__((unused)) void*
         filename++;  // Strip leading '/'
 
         if (strcmp(method, "POST") == 0)
-            post_request(request, filename);
+            post_request(request, filename, restart_dockerd_void_ptr);
         else if (strcmp(method, "DELETE") == 0)
             delete_request(request, filename);
         else

--- a/app/http_request.h
+++ b/app/http_request.h
@@ -1,4 +1,6 @@
 #pragma once
 
 // Callback function called from a thread by the FCGI server
-void http_request_callback(void* request_void_ptr, void* userdata);
+void http_request_callback(void* request_void_ptr, void* restart_dockerd_void_ptr);
+
+typedef void (*restart_dockerd_t)(void);


### PR DESCRIPTION
Just as when changing a VAPIX parameter, completing a file upload over HTTP will restart dockerd.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
