### PR TITLE
Clean up docker.pid file in /var/run/user

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -687,9 +687,9 @@ static void dockerd_process_exited_callback(GPid pid, gint status, gpointer app_
     dockerd_process_pid = -1;
     g_spawn_close_pid(pid);
 
-    // The lockfile might have been left behind if dockerd shut down in a bad
-    // manner. Remove it manually.
-    remove("/var/run/docker.pid");
+    // The lockfile might have been left behind if dockerd shut down in a bad manner.
+    g_autofree char* pid_path = g_strdup_printf("/var/run/user/%d/docker.pid", getuid());
+    remove(pid_path);
 
     main_loop_quit();  // Trigger a restart of dockerd from main()
 }


### PR DESCRIPTION
Clean up docker.pid file in /var/run/user instead of in the old rooted location of /var/run/docker.pid 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
