### PR TITLE
Removed typos with compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ It's also possible to build and use a locally built image. See the
 
 ## Securing the Docker ACAP using TLS
 
-The Docker Compose ACAP application can be run in either TLS mode or unsecured mode. The Docker Compose
+The Docker ACAP application can be run in either TLS mode or unsecured mode. The Docker
 ACAP application uses TLS mode by default. It is important to note that Dockerd will fail to start if
 TCP socket or IPC socket parameters are not selected, one of these sockets must be set to `yes`.
 
 Use the "Use TLS" and "TCP Socket" dropdowns in the web interface to switch between the
 two different modes(yes/no). Whenever these settings change, the Docker daemon will automatically restart.
 It's also possible to toggle this option by calling the parameter management API in
-[VAPIX](https://www.axis.com/vapix-library/) and setting `root.dockerdwrapperwithcompose.UseTLS` and
-`root.dockerdwrapperwithcompose.TCPSocket` parameters to `yes` or `no`.
+[VAPIX](https://www.axis.com/vapix-library/) and setting `root.dockerdwrapper.UseTLS` and
+`root.dockerdwrapper.TCPSocket` parameters to `yes` or `no`.
 The following commands would enable those parameters:
 
 ```sh
@@ -102,7 +102,7 @@ Enable TCP Socket:
 
 ```sh
 curl -s --anyauth -u "root:$DEVICE_PASSWORD" \
-  "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapperwithcompose.TCPSocket=yes"
+  "http://$DEVICE_IP/axis-cgi/param.cgi?action=update&root.dockerdwrapper.TCPSocket=yes"
 ```
 
 Note that the dockerd service will be restarted every time TLS is activated or


### PR DESCRIPTION
Do not refer to Docker Compose ACAP in the README this repo
