### PR TITLE
Remove unnecessary check that child process was started

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -634,12 +634,6 @@ static bool start_dockerd(const struct settings* settings, struct app_state* app
     // Watch the child process.
     g_child_watch_add(dockerd_process_pid, dockerd_process_exited_callback, app_state);
 
-    if (!is_process_alive(dockerd_process_pid)) {
-        log_error("Starting dockerd failed: Process died unexpectedly during startup");
-        quit_program(EX_SOFTWARE);
-        set_status_parameter(param_handle, STATUS_NOT_STARTED);
-        goto end;
-    }
     set_status_parameter(param_handle, STATUS_RUNNING);
     return_value = true;
 


### PR DESCRIPTION
Even if the child process dies immediately after being launched, the call to g_child_watch_add() will register a callback that will alert the application of the exit code when the main loop is reached.

In this case, status will briefly change to STATUS_RUNNING before changing to DOCKERD_RUNTIME_ERROR.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
