### PR TITLE
Do not set group in command to dockerd

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -562,12 +562,14 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
     if (use_ipc_socket) {
         g_strlcat(msg, " with IPC socket and", msg_len);
         uid_t uid = getuid();
-        uid_t gid = getgid();
         // The socket should reside in the user directory and have same group as user
+        // Ideally we would like to set the group ownership here but due to us
+        // now being in user ns the gid will be set incorrectly on the opened socket
+        // Instead we get a warning message that the 'docker' group is not found
+        // but the socket will be created with the 'addon' group as owner
         args_offset += g_snprintf(args + args_offset,
                                   args_len - args_offset,
-                                  " --group %d -H unix:///var/run/user/%d/docker.sock",
-                                  gid,
+                                  " -H unix:///var/run/user/%d/docker.sock",
                                   uid);
     } else {
         g_strlcat(msg, " without IPC socket and", msg_len);


### PR DESCRIPTION
If the `--group` is set we get an unknown id as group owner of the IPC socket, leading to that other users (in addon group) can't connect to the socket

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
