### PR TITLE
Set ownership of empty daemon.json when running postinstall as root

### DIFF
--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -9,5 +9,5 @@ fi
 if [ ! -e localdata/daemon.json ]; then
 	umask 077
 	echo "{}" >localdata/daemon.json
-	[ "$(id -u)" -ne 0 ] || chown $(stat -c %u.%g localdata) localdata/daemon.json
+	[ "$(id -u)" -ne 0 ] || chown "$(stat -c %u.%g localdata)" localdata/daemon.json
 fi

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -9,4 +9,5 @@ fi
 if [ ! -e localdata/daemon.json ]; then
 	umask 077
 	echo "{}" >localdata/daemon.json
+	[ $(id -u) -ne 0 ] || chown $(stat -c %u.%g localdata) localdata/daemon.json
 fi

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -9,5 +9,5 @@ fi
 if [ ! -e localdata/daemon.json ]; then
 	umask 077
 	echo "{}" >localdata/daemon.json
-	[ $(id -u) -ne 0 ] || chown $(stat -c %u.%g localdata) localdata/daemon.json
+	[ "$(id -u)" -ne 0 ] || chown $(stat -c %u.%g localdata) localdata/daemon.json
 fi


### PR DESCRIPTION
During a transition period, the postinstall script may run either as root or as the ACAP user, depending on global device settings. This needs to be taken into consideration when creating files from the postinstall script.

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
