### PR TITLE
Set IPC socket group ownership to addon

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -562,12 +562,13 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
     if (use_ipc_socket) {
         g_strlcat(msg, " with IPC socket and", msg_len);
         uid_t uid = getuid();
-        uid_t gid = getgid();
-        // The socket should reside in the user directory and have same group as user
+        // The socket should reside in the user directory and have same group as user.
+        // If omitted, dockerd will log a warning about the 'docker' group not being find.
+        // However, rootlesskit maps the user's primary group to the root group, so "--group 0"
+        // means the socket will belong to the user's primary group.
         args_offset += g_snprintf(args + args_offset,
                                   args_len - args_offset,
-                                  " --group %d -H unix:///var/run/user/%d/docker.sock",
-                                  gid,
+                                  " --group 0 -H unix:///var/run/user/%d/docker.sock",
                                   uid);
     } else {
         g_strlcat(msg, " without IPC socket and", msg_len);


### PR DESCRIPTION
The IPC socket should belong to group addon, so it can be accessed by other applications in the Docker Compose case.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
