### PR TITLE
Remove superfluous DOCKER_HOST variable

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -871,11 +871,9 @@ static bool set_env_variables(void) {
     g_autofree char* path =
         g_strdup_printf("/bin:/usr/bin:%s:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
                         APP_DIRECTORY);
-    g_autofree char* docker_host = g_strdup_printf("unix:///var/run/user/%d/docker.sock", uid);
     g_autofree char* xdg_runtime_dir = xdg_runtime_directory();
 
     return set_env_variable("PATH", path) && set_env_variable("HOME", APP_DIRECTORY) &&
-           set_env_variable("DOCKER_HOST", docker_host) &&
            set_env_variable("XDG_RUNTIME_DIR", xdg_runtime_dir);
 }
 


### PR DESCRIPTION
dockerd receives the socket specification from -H on the command line, either for IPC or TCP or both, while DOCKER_HOST can be used by the client.

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
