### PR TITLE
Simplify concatenation of formatted strings

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -450,7 +450,8 @@ static bool read_settings(struct settings* settings, const struct app_state* app
 // Return a command line with space-delimited argument based on the current settings.
 static const char* build_daemon_args(const struct settings* settings, AXParameter* param_handle) {
     static gchar args[1024];  // Pointer to args returned to caller on success.
-    const gsize args_len = sizeof(args);
+    const char* args_end = args + sizeof(args);
+    char* args_wr = args;  // Points to location of next write
 
     const char* data_root = settings->data_root;
     const bool use_tls = settings->use_tls;
@@ -459,7 +460,6 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
 
     gsize msg_len = 128;
     gchar msg[msg_len];
-    guint args_offset = 0;
 
     g_autofree char* log_level = get_parameter_value(param_handle, PARAM_DOCKERD_LOG_LEVEL);
 
@@ -472,42 +472,36 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
     IPbuffer = inet_ntoa(*((struct in_addr*)host_entry->h_addr_list[0]));
 
     // construct the rootlesskit command
-    args_offset += g_snprintf(args + args_offset,
-                              args_len - args_offset,
-                              "%s %s %s %s %s %s %s %s %s",
-                              "rootlesskit",
-                              "--subid-source=static",
-                              "--net=slirp4netns",
-                              "--disable-host-loopback",
-                              "--copy-up=/etc",
-                              "--copy-up=/run",
-                              "--propagation=rslave",
-                              "--port-driver slirp4netns",
-                              /* don't use same range as company proxy */
-                              "--cidr=10.0.3.0/24");
+    args_wr += g_snprintf(args_wr,
+                          args_end - args_wr,
+                          "%s %s %s %s %s %s %s %s %s",
+                          "rootlesskit",
+                          "--subid-source=static",
+                          "--net=slirp4netns",
+                          "--disable-host-loopback",
+                          "--copy-up=/etc",
+                          "--copy-up=/run",
+                          "--propagation=rslave",
+                          "--port-driver slirp4netns",
+                          /* don't use same range as company proxy */
+                          "--cidr=10.0.3.0/24");
 
     if (strcmp(log_level, "debug") == 0) {
-        args_offset += g_snprintf(args + args_offset, args_len - args_offset, " %s", "--debug");
+        args_wr += g_snprintf(args_wr, args_end - args_wr, " %s", "--debug");
     }
 
     const uint port = use_tls ? 2376 : 2375;
-    args_offset += g_snprintf(args + args_offset,
-                              args_len - args_offset,
-                              " -p %s:%d:%d/tcp",
-                              IPbuffer,
-                              port,
-                              port);
+    args_wr += g_snprintf(args_wr, args_end - args_wr, " -p %s:%d:%d/tcp", IPbuffer, port, port);
 
     // add dockerd command
-    args_offset += g_snprintf(args + args_offset,
-                              args_len - args_offset,
-                              " dockerd %s",
-                              "--config-file " APP_LOCALDATA "/" DAEMON_JSON);
+    args_wr += g_snprintf(args_wr,
+                          args_end - args_wr,
+                          " dockerd %s",
+                          "--config-file " APP_LOCALDATA "/" DAEMON_JSON);
 
     g_strlcpy(msg, "Starting dockerd", msg_len);
 
-    args_offset +=
-        g_snprintf(args + args_offset, args_len - args_offset, " --log-level=%s", log_level);
+    args_wr += g_snprintf(args_wr, args_end - args_wr, " --log-level=%s", log_level);
 
     if (use_ipc_socket) {
         g_strlcat(msg, " with IPC socket and", msg_len);
@@ -516,39 +510,28 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
         // However, rootlesskit maps the user's primary group to the root group, so "--group 0"
         // means the socket will belong to the user's primary group.
         g_autofree char* ipc_socket = xdg_runtime_file("docker.sock");
-        args_offset += g_snprintf(args + args_offset,
-                                  args_len - args_offset,
-                                  " --group 0 -H unix://%s",
-                                  ipc_socket);
+        args_wr += g_snprintf(args_wr, args_end - args_wr, " --group 0 -H unix://%s", ipc_socket);
     } else {
         g_strlcat(msg, " without IPC socket and", msg_len);
     }
 
     if (use_tcp_socket) {
         g_strlcat(msg, " with TCP socket", msg_len);
+        g_strlcat(msg, use_tls ? " in TLS mode" : " in unsecured mode", msg_len);
         const uint port = use_tls ? 2376 : 2375;
-        args_offset +=
-            g_snprintf(args + args_offset, args_len - args_offset, " -H tcp://0.0.0.0:%d", port);
-        if (use_tls) {
-            args_offset += g_snprintf(args + args_offset,
-                                      args_len - args_offset,
-                                      " %s",
-                                      tls_args_for_dockerd());
-            g_strlcat(msg, " in TLS mode", msg_len);
-        } else {
-            args_offset += g_snprintf(args + args_offset, args_len - args_offset, " --tls=false");
-            g_strlcat(msg, " in unsecured mode", msg_len);
-        }
+        args_wr += g_snprintf(args_wr, args_end - args_wr, " -H tcp://0.0.0.0:%d", port);
+        const char* tls_arg = use_tls ? "--tlsverify=true" : "--tls=false";
+        args_wr += g_snprintf(args_wr, args_end - args_wr, " %s", tls_arg);
+        if (use_tls)
+            args_wr += g_snprintf(args_wr, args_end - args_wr, " %s", tls_file_dockerd_args());
     } else {
         g_strlcat(msg, " without TCP socket", msg_len);
     }
 
-    {
-        g_autofree char* data_root_msg = g_strdup_printf(" using %s as storage.", data_root);
-        g_strlcat(msg, data_root_msg, msg_len);
-        args_offset +=
-            g_snprintf(args + args_offset, args_len - args_offset, " --data-root %s", data_root);
-    }
+    g_autofree char* data_root_msg = g_strdup_printf(" using %s as storage.", data_root);
+    g_strlcat(msg, data_root_msg, msg_len);
+    args_wr += g_snprintf(args_wr, args_end - args_wr, " --data-root %s", data_root);
+
     log_info("%s", msg);
     return args;
 }
@@ -560,13 +543,11 @@ static bool start_dockerd(const struct settings* settings, struct app_state* app
     GError* error = NULL;
     bool result = false;
     bool return_value = false;
-    const char* args;
-    gchar** args_split = NULL;
 
-    args = build_daemon_args(settings, param_handle);
+    const char* args = build_daemon_args(settings, param_handle);
 
     log_debug("Sending daemon start command: %s", args);
-    args_split = g_strsplit(args, " ", 0);
+    char** args_split = g_strsplit(args, " ", 0);
     result = g_spawn_async(NULL,
                            args_split,
                            NULL,

--- a/app/tls.c
+++ b/app/tls.c
@@ -58,18 +58,19 @@ const char* tls_file_description(const char* filename) {
     return NULL;
 }
 
-const char* tls_args_for_dockerd(void) {
+const char* tls_file_dockerd_args(void) {
     static char args[512];  // Too small buffer will cause truncated options, nothing more.
     const char* end = args + sizeof(args);
-    char* ptr = args + g_snprintf(args, end - args, "--tlsverify");
+    char* ptr = args;
 
     for (size_t i = 0; i < NUM_TLS_CERTS; ++i)
         ptr += g_snprintf(ptr,
                           end - ptr,
-                          " %s %s/%s",
+                          "%s %s/%s ",
                           tls_certs[i].dockerd_option,
                           TLS_CERT_PATH,
                           tls_certs[i].filename);
+    ptr[-1] = '\0';  // Remove space after last item.
     return args;
 }
 

--- a/app/tls.h
+++ b/app/tls.h
@@ -4,5 +4,5 @@
 bool tls_missing_certs(void);
 void tls_log_missing_cert_warnings(void);
 const char* tls_file_description(const char* filename);
-const char* tls_args_for_dockerd(void);
+const char* tls_file_dockerd_args(void);
 bool tls_file_has_correct_format(const char* filename, const char* path_to_file);


### PR DESCRIPTION
Instead of keeping track of offset into and length of buffer, keep track of pointers to next input and to end of buffer. This means one less subtraction in every call to g_snprintf() and occationally statements that don't have to span several lines.

The --tlsverify flag was also moved from tls.c to the main file.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
