### PR TITLE
Remove unnecessary cleanup of AXParameter callbacks

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -848,15 +848,7 @@ int main(int argc, char** argv) {
     fcgi_stop();
 
     set_status_parameter(app_state.param_handle, STATUS_NOT_STARTED);
-
-    if (app_state.param_handle != NULL) {
-        for (size_t i = 0; i < sizeof(ax_parameters) / sizeof(ax_parameters[0]); ++i) {
-            char* parameter_path = g_strdup_printf("root.%s.%s", APP_NAME, ax_parameters[i]);
-            ax_parameter_unregister_callback(app_state.param_handle, parameter_path);
-            free(parameter_path);
-        }
-        ax_parameter_free(app_state.param_handle);
-    }
+    ax_parameter_free(app_state.param_handle);
 
     sd_disk_storage_free(sd_disk_storage);
     free(app_state.sd_card_area);


### PR DESCRIPTION
There is no need to unregister AXParameter callbacks. The hash table used for storing them will free its contents in ax_parameter_free().

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
