### PR TITLE
Free resources in the reverse order of allocation

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -843,7 +843,8 @@ int main(int argc, char** argv) {
 
         stop_dockerd();
     }
-    main_loop_unref();
+
+    sd_disk_storage_free(sd_disk_storage);
 
     fcgi_stop();
 
@@ -858,8 +859,9 @@ int main(int argc, char** argv) {
         ax_parameter_free(app_state.param_handle);
     }
 
-    sd_disk_storage_free(sd_disk_storage);
     free(app_state.sd_card_area);
+
+    main_loop_unref();
 
     log_debug("Application exited with exit code %d", application_exit_code);
     return application_exit_code;


### PR DESCRIPTION
When resources are freed in the reverse order as they are allocated, it simplifies when you want to disable parts of the code when hunting for memory leaks and undefined behavior.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
