### PR TITLE
Handle HTTP requests one-by-one

### DIFF
--- a/app/fcgi_server.h
+++ b/app/fcgi_server.h
@@ -1,6 +1,7 @@
 #pragma once
+#include <fcgiapp.h>
 
-typedef void (*fcgi_request_callback)(void* request_void_ptr, void* userdata);
+typedef void (*fcgi_request_callback)(FCGX_Request* request, void* userdata);
 
 int fcgi_start(fcgi_request_callback request_callback, void* request_callback_parameter);
 void fcgi_stop(void);

--- a/app/http_request.c
+++ b/app/http_request.c
@@ -119,9 +119,7 @@ static void malformed_request(FCGX_Request* request, const char* method, const c
     response_msg(request, HTTP_400_BAD_REQUEST, "Malformed request");
 }
 
-void http_request_callback(void* request_void_ptr, void* restart_dockerd_context_void_ptr) {
-    FCGX_Request* request = (FCGX_Request*)request_void_ptr;
-
+void http_request_callback(FCGX_Request* request, void* restart_dockerd_context_void_ptr) {
     const char* method = FCGX_GetParam("REQUEST_METHOD", request->envp);
     const char* uri = FCGX_GetParam("REQUEST_URI", request->envp);
 

--- a/app/http_request.h
+++ b/app/http_request.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <fcgiapp.h>
 
 struct app_state;
 
@@ -10,4 +11,4 @@ struct restart_dockerd_context {
 };
 
 // Callback function called from a thread by the FCGI server
-void http_request_callback(void* request_void_ptr, void* restart_dockerd_context_void_ptr);
+void http_request_callback(FCGX_Request* request, void* restart_dockerd_context_void_ptr);


### PR DESCRIPTION
By handling HTTP requests one-by-one rather than spawning a thread for each request, an attacker can no longer force the app to create multiple threads. It also leads to simpler code and fixes the failure to free the memory allocated for the request.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
