### PR TITLE
Add option for building with sanitizers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,8 +140,11 @@ COPY --from=docker_binaries \
     /download/rootlesskit-docker-proxy \
     /download/slirp4netns ./
 
+ARG BUILD_WITH_SANITIZERS
+
 RUN <<EOF
     . /opt/axis/acapsdk/environment-setup*
+    BUILD_WITH_SANITIZERS="$BUILD_WITH_SANITIZERS" \
     acap-build . \
         -a dockerd \
         -a docker-init \

--- a/README.md
+++ b/README.md
@@ -435,6 +435,17 @@ where `<build-folder>` is the path to an output folder on your machine, eg. `bui
 created for you if not already existing. Once the build has completed the EAP file can be found
 in the `<build-folder>`.
 
+### Build options
+
+In order to build with debug symbols and sanitizing instrumentation for detecting memory leaks and undefined behavior,
+add the option
+
+```sh
+--build-arg BUILD_WITH_SANITIZERS=1
+```
+
+to the docker command line above.
+
 ## Contributing
 
 Take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) file.

--- a/app/Makefile
+++ b/app/Makefile
@@ -10,6 +10,11 @@ CFLAGS += -W -Wformat=2 -Wpointer-arith -Wbad-function-cast -Wstrict-prototypes 
 		-Wno-unused-variable \
 		-D APP_NAME=\"$(PROG1)\"
 
+ifdef BUILD_WITH_SANITIZERS
+    CFLAGS += -g -fsanitize=address -fsanitize=leak -fsanitize=undefined
+    LDFLAGS += -static-libasan -static-liblsan -static-libubsan
+endif
+
 all: $(PROG1)
 
 $(PROG1): $(OBJS1)

--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,7 @@ done
 docker buildx build --build-arg ARCH="$arch" \
 	--build-arg HTTP_PROXY="${HTTP_PROXY:-}" \
 	--build-arg HTTPS_PROXY="${HTTPS_PROXY:-}" \
+	--build-arg BUILD_WITH_SANITIZERS="${BUILD_WITH_SANITIZERS:-}" \
 	--file Dockerfile \
 	$progress_arg \
 	$cache_arg \


### PR DESCRIPTION
If enabled, the code will contain instrumentation that checks for various errors, reports them on stdout and results in a non-zero exit code.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
