### PR TITLE
Set dockerd default log-level to warning

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -50,7 +50,7 @@
                 },
                 {
                     "name": "DockerdLogLevel",
-                    "default": "info",
+                    "default": "warn",
                     "type": "enum:debug,info,warn,error,fatal"
                 },
                 {


### PR DESCRIPTION
Reduce the default log level of dockerd to `warn`

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
