### PR TITLE
Remove repetitive log messages

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -800,17 +800,13 @@ int main(int argc, char** argv) {
     allow_dockerd_to_start(&app_state, true);
 
     app_state.param_handle = setup_axparameter(&app_state);
-    if (!app_state.param_handle) {
-        log_error("Error in setup_axparameter");
+    if (!app_state.param_handle)
         return EX_SOFTWARE;
-    }
 
     log_debug_set(is_app_log_level_debug(app_state.param_handle));
 
-    if (!set_env_variables()) {
-        log_error("Failed to set environment variables");
+    if (!set_env_variables())
         return EX_SOFTWARE;
-    }
 
     init_signals();
 


### PR DESCRIPTION
If AXParameter or environment variable setup fails, a detailed message is already logged in the failing function. There is no need to repeat that message with less detail at the call site.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
