### PR TITLE
Log missing TLS certificates as a warning rather than an error

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -412,12 +412,8 @@ static bool read_settings(struct settings* settings, const struct app_state* app
         // when TCP won't be used. If the setting is changed we will loop through
         // this function again.
         settings->use_tls = false;
-    else {
-        if (!get_and_verify_tls_selection(param_handle, &settings->use_tls)) {
-            log_error("Failed to verify tls selection");
-            return false;
-        }
-    }
+    else if (!get_and_verify_tls_selection(param_handle, &settings->use_tls))
+        return false;
 
     settings->use_ipc_socket = is_parameter_yes(param_handle, PARAM_IPC_SOCKET);
 


### PR DESCRIPTION
TLS is enabled by default and uploading certificates over HTTP needs to happen after the application has started, so the user cannot avoid this message when using HTTP rather than SSH.

The warning message already exists in tls_log_missing_cert_certs(), so this change only removes the generic error message at the call site.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
