### PR TITLE
Log missing SD card as a warning rather than an error

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -371,7 +371,7 @@ static bool is_app_log_level_debug(AXParameter* param_handle) {
 static char* prepare_data_root(AXParameter* param_handle, const char* sd_card_area) {
     if (is_parameter_yes(param_handle, PARAM_SD_CARD_SUPPORT)) {
         if (!sd_card_area) {
-            log_error("SD card was requested, but no SD card is available at the moment.");
+            log_warning("SD card was requested, but no SD card is available at the moment.");
             set_status_parameter(param_handle, STATUS_NO_SD_CARD);
             return NULL;
         }


### PR DESCRIPTION
It takes a few moments for the SD card to become available, so if the SD card setting is enabled, this log message will show up every time the application starts.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
