### PR TITLE
Try to change ownership of files on SD card during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ Following are the possible values of `Status`:
                                  The application is running but dockerd is stopped.
                                  Make sure no directories with the wrong user permissions are left on
                                  the SD card, then restart the application.
+                                 This can be achieved by [allowing root-privileged apps][vapix-allow-root],
+                                 reinstalling the application, then disallowing root-privileged apps again,
+                                 since the post-install script will attempt to repair the permissions when
+                                 running as root.
 
 ### Using TLS to secure the application
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ contains known limitations when running rootless Docker.
 <!-- omit in toc -->
 ### Known Issues
 
+- When using the SD card for this application, the file permissions can sometimes be set incorrectly
+  during an upgrade of the device firmware or the application.
+  See [Using an SD card as storage](#using-an-sd-card-as-storage) for information on how to handle this.
+
 - Only uid and gid are properly mapped between device and containers, not the secondary groups that the
 user is a member of. This means that resources on the device, even if they are volume or device mounted,
 can be inaccessible inside the container. This can also affect usage of unsupported D-Bus methods from
 the container. See [Using host user secondary groups in container](#using-host-user-secondary-groups-in-container)
-for how to handle this.
+for information on how to handle this.
 
 ## Requirements
 
@@ -224,11 +228,8 @@ Following are the possible values of `Status`:
                                  correct file permissions to use it.
                                  The application is running but dockerd is stopped.
                                  Make sure no directories with the wrong user permissions are left on
-                                 the SD card, then restart the application.
-                                 This can be achieved by [allowing root-privileged apps][vapix-allow-root],
-                                 reinstalling the application, then disallowing root-privileged apps again,
-                                 since the post-install script will attempt to repair the permissions when
-                                 running as root.
+                                 the SD card, then restart the application. For further information see
+                                 [Using an SD card as storage](#using-an-sd-card-as-storage).
 
 ### Using TLS to secure the application
 
@@ -335,6 +336,9 @@ To get more informed about specifications, check the
 >remove the directory that is used by the application.
 >For versions before 2.0 the path was `/var/spool/storage/SD_DISK/dockerd`.
 >For versions from 2.0 the path is `/var/spool/storage/areas/SD_DISK/<application-name>`.
+>Alternatively, this can be achieved by [allowing root-privileged apps][vapix-allow-root],
+>reinstalling the application, then disallowing root-privileged apps again,
+>since the post-install script will attempt to repair the permissions when running as root.
 
 ### Using the application
 

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -11,3 +11,10 @@ if [ ! -e localdata/daemon.json ]; then
 	echo "{}" >localdata/daemon.json
 	[ "$(id -u)" -ne 0 ] || chown "$(stat -c %u.%g localdata)" localdata/daemon.json
 fi
+
+# ACAP framework does not handle ownership on SD card, which causes problem when the app user ID changes.
+# If run as root, this script will repair the ownership.
+SD_CARD_AREA=/var/spool/storage/SD_DISK/areas/"$(basename "$(pwd)")"
+if [ "$(id -u)" -eq 0 -a -d "$SD_CARD_AREA" ]; then
+	chown -R "$(stat -c %u.%g localdata)" "$SD_CARD_AREA"
+fi

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -15,6 +15,6 @@ fi
 # ACAP framework does not handle ownership on SD card, which causes problem when the app user ID changes.
 # If run as root, this script will repair the ownership.
 SD_CARD_AREA=/var/spool/storage/SD_DISK/areas/"$(basename "$(pwd)")"
-if [ "$(id -u)" -eq 0 -a -d "$SD_CARD_AREA" ]; then
+if [ "$(id -u)" -eq 0 ] && [ -d "$SD_CARD_AREA" ]; then
 	chown -R "$(stat -c %u.%g localdata)" "$SD_CARD_AREA"
 fi


### PR DESCRIPTION
When 'Allow root-privileged apps' is turned on,
the post-install script will run as root,
so it has the ability to change the ownership of the files on the SD card

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
