### PR TITLE
Avoid truncation of startup message

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -520,7 +520,7 @@ static const char* build_daemon_args(const struct settings* settings, AXParamete
     const bool use_tcp_socket = settings->use_tcp_socket;
     const bool use_ipc_socket = settings->use_ipc_socket;
 
-    gsize msg_len = 128;
+    gsize msg_len = 256;
     gchar msg[msg_len];
 
     g_autofree char* log_level = get_parameter_value(param_handle, PARAM_DOCKERD_LOG_LEVEL);


### PR DESCRIPTION
The buffer holding the message "Starting dockerd with..." is currently too short and the final part, "as storage", will be truncated for certain combinations of settings.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
