### PR TITLE
Decrease the wait time before SIGKILL

### DIFF
--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -653,7 +653,7 @@ static bool send_signal(const char* name, GPid pid, int sig) {
 // Otherwise, it will be increased, and SIGTERM will be sent on the 20th call.
 static gboolean monitor_dockerd_termination(void* time_since_sigterm_void_ptr) {
     // dockerd usually sends SIGTERM to containers after 10 s, so we must wait a bit longer.
-    const int time_to_wait_before_sigkill = 20;
+    const int time_to_wait_before_sigkill = 13;
     int* time_since_sigterm = (int*)time_since_sigterm_void_ptr;
     if (!rootlesskit_pid) {
         log_debug("rootlesskit exited after %d s", *time_since_sigterm);

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -653,8 +653,8 @@ static bool send_signal(const char* name, GPid pid, int sig) {
 // Otherwise, it will be increased, and SIGTERM will be sent on the 20th call.
 static gboolean monitor_dockerd_termination(void* time_since_sigterm_void_ptr) {
     // dockerd usually sends SIGTERM to containers after 10 seconds and systemd forcefully shutdown
-    // the process after 15 seconds, so we must wait slightly longer than 10 seconds but not more
-    // than 15 seconds.
+    // the process approximately at 14-15 seconds, so we must wait slightly longer than 10 seconds
+    // but not more than 15 seconds.
     const int time_to_wait_before_sigkill = 13;
     int* time_since_sigterm = (int*)time_since_sigterm_void_ptr;
     if (!rootlesskit_pid) {

--- a/app/dockerdwrapper.c
+++ b/app/dockerdwrapper.c
@@ -652,7 +652,9 @@ static bool send_signal(const char* name, GPid pid, int sig) {
 // pointer to a counter starting at 1. When dockerd has terminated, the counter will be set to zero.
 // Otherwise, it will be increased, and SIGTERM will be sent on the 20th call.
 static gboolean monitor_dockerd_termination(void* time_since_sigterm_void_ptr) {
-    // dockerd usually sends SIGTERM to containers after 10 s, so we must wait a bit longer.
+    // dockerd usually sends SIGTERM to containers after 10 seconds and systemd forcefully shutdown
+    // the process after 15 seconds, so we must wait slightly longer than 10 seconds but not more
+    // than 15 seconds.
     const int time_to_wait_before_sigkill = 13;
     int* time_since_sigterm = (int*)time_since_sigterm_void_ptr;
     if (!rootlesskit_pid) {


### PR DESCRIPTION
### Describe your changes
 
Docker daemon (dockerd) typically sends a SIGTERM signal after 10 seconds. Previously, we waited 20 seconds before sending a SIGKILL, but systemd would sometimes reach its timeout and forcefully terminate the process before then approximately at 14-15 seconds. To prevent this issue I havve decreased the wait time to 13 seconds before sending SIGKILL.  SIGTERM sometimes stops the process gracefully but it’s not always reliable so making this change is necessary.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
