### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,9 @@ on:
 env:
   PROJECT: "docker-acap"
 
+permissions:
+  contents: read
+
 jobs:
   # Builds docker ACAP using the build.sh script, then signs the eap-file in
   # ACAP Portal and stores it as a build artifact.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/send-dispatch.yml
+++ b/.github/workflows/send-dispatch.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - ".github/*"
 
+permissions:
+  contents: read
+
 jobs:
   send-dispatch:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/cd.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/send-dispatch.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.