### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,13 +41,13 @@ jobs:
       EAP_FILE_AARCH64: ${{ steps.save_full_file_name.outputs.EAP_FILE_AARCH64 }}
       SHORT_SHA: ${{ steps.save_full_file_name.outputs.SHORT_SHA }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: get_short_sha
         run: |
           sha=${{ github.sha }}
           strip_sha=${sha:0:7}
           echo "SHORT_SHA=${strip_sha}" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: ${{ (github.ref_type == 'tag') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         with:
           path: ${{ github.workspace }}/build-${{ matrix.arch }}
@@ -153,7 +153,7 @@ jobs:
           else
               echo "::error::Non valid architecture '${{ matrix.arch }}' encountered"
           fi
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/build-${{ matrix.arch }}
           key: key-${{ env.SHORT_SHA }}-${{ github.run_id }}-${{ matrix.arch }}
@@ -187,7 +187,7 @@ jobs:
             echo "HTTP_RESPONSE is empty or not a valid integer: $HTTP_RESPONSE"
           fi
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.SIGNED_EAP_FILE }}
           path: build/${{ env.SIGNED_EAP_FILE }}
@@ -219,7 +219,7 @@ jobs:
         id: vars
         run: echo "TAG=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
       - name: Create prerelease
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -269,7 +269,7 @@ jobs:
             echo "::error::Non valid architecture '${{ matrix.arch }}' encountered"
           fi
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ env.EAP_FILE }}
           path: ./

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Lint codebase
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/cd.yml`
- `.github/workflows/lint.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.